### PR TITLE
Enabling Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "gradle"
+    directory: "/"
+    schedule:
+      interval: "daily"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -17,9 +17,10 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Set up JDK 8
-      uses: actions/setup-java@v1
+      uses: actions/setup-java@v2
       with:
-        java-version: 1.8
+        distribution: 'zulu'
+        java-version: 8
     - name: Grant execute permission for gradlew
       run: chmod +x gradlew
     - name: Build with Gradle


### PR DESCRIPTION
Enabling Dependabot. Its a bot supported by Github that will look at updating dependency versions and generating automatically PRs. Example https://github.com/Netflix/dgs-examples-java/pull/14

https://docs.github.com/en/code-security/supply-chain-security/configuring-dependabot-security-updates