### PR TITLE
Make sure the settings reflect the project name

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -14,4 +14,4 @@
  * limitations under the License.
  */
 
-rootProject.name = "demo"
+rootProject.name = "dgs-examples-kotlin"


### PR DESCRIPTION
The current Gradle settings name the project only as _demo_.