### PR TITLE
Include the usage of Kotlin Coroutines in Data Fetchers

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -43,8 +43,11 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-web")
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
     implementation("com.github.javafaker:javafaker:1.+")
+    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core")
+    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-jdk8")
 
     testImplementation("org.springframework.boot:spring-boot-starter-test")
+    testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test")
 }
 
 tasks.withType<com.netflix.graphql.dgs.codegen.gradle.GenerateJavaTask> {

--- a/src/main/kotlin/com/example/demo/datafetchers/ShowsDataFetcher.kt
+++ b/src/main/kotlin/com/example/demo/datafetchers/ShowsDataFetcher.kt
@@ -16,24 +16,26 @@
 
 package com.example.demo.datafetchers
 
-import com.example.demo.generated.DgsConstants
 import com.example.demo.generated.types.Show
 import com.example.demo.services.ShowsService
 import com.netflix.graphql.dgs.DgsComponent
-import com.netflix.graphql.dgs.DgsData
 import com.netflix.graphql.dgs.DgsQuery
 import com.netflix.graphql.dgs.InputArgument
-import org.springframework.beans.factory.annotation.Autowired
+
+import kotlinx.coroutines.coroutineScope
 
 @DgsComponent
 class ShowsDataFetcher(private val showsService: ShowsService) {
+
     /**
-     * This datafetcher resolves the shows field on Query.
+     * This datafetcher resolves the `shows` field on Query.
      * It uses an @InputArgument to get the titleFilter from the Query if one is defined.
+     * As an implementation detail, it leverages Kotlin Coroutines as an output type.
+     *
      */
     @DgsQuery
-    fun shows(@InputArgument titleFilter : String?): List<Show> {
-        return if(titleFilter != null) {
+    suspend fun shows(@InputArgument titleFilter : String?): List<Show> = coroutineScope {
+        if(titleFilter != null) {
             showsService.shows().filter { it.title.contains(titleFilter) }
         } else {
             showsService.shows()

--- a/src/test/kotlin/com/example/demo/DgsExampleSmokeTest.kt
+++ b/src/test/kotlin/com/example/demo/DgsExampleSmokeTest.kt
@@ -1,0 +1,54 @@
+package com.example.demo
+
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers
+
+/**
+ * Example of a smoke test that will interact with the HTTP /graphql endpoint via MockMVC
+ */
+@SpringBootTest
+@EnableAutoConfiguration
+@AutoConfigureMockMvc
+class DgsExampleSmokeTest {
+
+    @Autowired
+    lateinit var mvc: MockMvc
+
+    @Test
+    fun `Queries for shows`() {
+        mvc.perform(
+            MockMvcRequestBuilders
+                .post("/graphql")
+                .content(
+                    """
+                        | {
+                        |   "query": "query some_movies { shows { title releaseYear } }"
+                        | }""".trimMargin()
+                )
+        ).andExpect(MockMvcResultMatchers.status().isOk)
+            .andExpect(
+                MockMvcResultMatchers.content().json(
+                    """
+                    | {
+                    |  "data": {
+                    |    "shows":[
+                    |      { "title":"Stranger Things", "releaseYear":2016 },
+                    |      { "title":"Ozark", "releaseYear":2017 },
+                    |      { "title":"The Crown","releaseYear":2016 },
+                    |      {"title":"Dead to Me","releaseYear":2019},
+                    |      {"title":"Orange is the New Black","releaseYear":2013}
+                    |    ]
+                    |  }
+                    |}
+                    |""".trimMargin(),
+                    false
+                )
+            )
+    }
+}

--- a/src/test/kotlin/com/example/demo/datafetchers/ShowsDataFetcherTest.kt
+++ b/src/test/kotlin/com/example/demo/datafetchers/ShowsDataFetcherTest.kt
@@ -32,7 +32,6 @@ import com.jayway.jsonpath.TypeRef
 import com.netflix.graphql.dgs.DgsQueryExecutor
 import com.netflix.graphql.dgs.autoconfig.DgsAutoConfiguration
 import com.netflix.graphql.dgs.client.codegen.GraphQLQueryRequest
-import graphql.ExecutionResult
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test


### PR DESCRIPTION
This commit moves our ShowsDataFetcher to be implemented via a Kotlin Coroutine. This will help us demo the ability to do so as well as ensure we don't break it in future releases.