### PR TITLE
Set content-type application/json when calling a GraphQL Endpoint.

### DIFF
--- a/.sdkmanrc
+++ b/.sdkmanrc
@@ -1,3 +1,3 @@
 # Enable auto-env through the sdkman_auto_env config
 # Add key=value pairs of SDKs to use below
-java=8.0.292-zulu
+java=8.0.332-zulu

--- a/src/test/kotlin/com/example/demo/DgsExampleSmokeTest.kt
+++ b/src/test/kotlin/com/example/demo/DgsExampleSmokeTest.kt
@@ -5,6 +5,7 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
 import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.http.MediaType
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers
@@ -25,6 +26,7 @@ class DgsExampleSmokeTest {
         mvc.perform(
             MockMvcRequestBuilders
                 .post("/graphql")
+                .contentType(MediaType.APPLICATION_JSON)
                 .content(
                     """
                         | { 


### PR DESCRIPTION
As a best practice we should set the content-type to application/json or application/graphql when calling a graphql endpoint.