### PR TITLE
handle nullability due to breaking changes in DataLoader v4.0.0

### DIFF
--- a/src/main/kotlin/com/example/demo/datafetchers/ReviewsDataFetcher.kt
+++ b/src/main/kotlin/com/example/demo/datafetchers/ReviewsDataFetcher.kt
@@ -46,7 +46,7 @@ class ReviewsDataFetcher(private val reviewsService: ReviewsService) {
         val show : Show? = dfe.getSource()
 
         //Load the reviews from the DataLoader. This call is async and will be batched by the DataLoader mechanism.
-        return reviewsDataLoader.load(show?.id)
+        return show?.id?.let { reviewsDataLoader.load(it) } ?: CompletableFuture.completedFuture(emptyList())
     }
 
     @DgsMutation


### PR DESCRIPTION
[changes in the dataloader](https://github.com/graphql-java/java-dataloader/commit/3060a30e60871f50eb685ada5337aa7a9e7e5112) causes strict nullability checks in kotlin at compile time.  